### PR TITLE
ruoyi-vue-pro issue #303 菜单管理中设置菜单路由参数 前端部分

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -6,7 +6,7 @@ VUE_APP_TITLE = 芋道管理系统
 
 # 芋道管理系统/本地环境
 # VUE_APP_BASE_API = '/proxy-api'
-VUE_APP_BASE_API = 'http://127.0.0.1:48080'
+VUE_APP_BASE_API = 'http://127.0.0.1:8080'
 
 # 路由懒加载
 VUE_CLI_BABEL_TRANSPILE_MODULES = true

--- a/.env.local
+++ b/.env.local
@@ -6,7 +6,7 @@ VUE_APP_TITLE = 芋道管理系统
 
 # 芋道管理系统/本地环境
 # VUE_APP_BASE_API = '/proxy-api'
-VUE_APP_BASE_API = 'http://127.0.0.1:8080'
+VUE_APP_BASE_API = 'http://127.0.0.1:48080'
 
 # 路由懒加载
 VUE_CLI_BABEL_TRANSPILE_MODULES = true

--- a/src/layout/components/Sidebar/Link.vue
+++ b/src/layout/components/Sidebar/Link.vue
@@ -10,7 +10,7 @@ import { isExternal } from '@/utils/validate'
 export default {
   props: {
     to: {
-      type: String,
+      type: [String,Object],
       required: true
     }
   },

--- a/src/layout/components/Sidebar/SidebarItem.vue
+++ b/src/layout/components/Sidebar/SidebarItem.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="!item.hidden">
     <template v-if="hasOneShowingChild(item.children,item) && (!onlyOneChild.children||onlyOneChild.noShowingChildren)&&!item.alwaysShow">
-      <app-link v-if="onlyOneChild.meta" :to="resolvePath(onlyOneChild.path)">
+      <app-link v-if="onlyOneChild.meta" :to="resolvePath(onlyOneChild.path,onlyOneChild.query)">
         <el-menu-item :index="resolvePath(onlyOneChild.path)" :class="{'submenu-title-noDropdown':!isNest}">
           <item :icon="onlyOneChild.meta.icon||(item.meta&&item.meta.icon)" :title="onlyOneChild.meta.title" />
         </el-menu-item>
@@ -82,12 +82,16 @@ export default {
 
       return false
     },
-    resolvePath(routePath) {
+    resolvePath(routePath,routeQuery) {
       if (isExternal(routePath)) {
         return routePath
       }
       if (isExternal(this.basePath)) {
         return this.basePath
+      }
+      if (routeQuery) {
+        let query = JSON.parse(routeQuery);
+        return { path: path.resolve(this.basePath, routePath), query: query }
       }
       return path.resolve(this.basePath, routePath)
     }

--- a/src/views/system/menu/index.vue
+++ b/src/views/system/menu/index.vue
@@ -109,6 +109,17 @@
               <el-input v-model="form.path" placeholder="请输入路由地址" />
             </el-form-item>
           </el-col>
+          <el-col :span="12">
+            <el-form-item v-if="form.type == 2" label="路由参数" prop="query">
+              <span slot="label">
+                <el-tooltip content='访问路由的默认传递参数，如：`{"id": 1, "name": "ry"}`' placement="top">
+                <i class="el-icon-question" />
+                </el-tooltip>
+                路由参数
+              </span>
+              <el-input v-model="form.query" placeholder="请输入路由参数" />
+            </el-form-item>
+          </el-col>
 					<el-col :span="12">
 						<el-form-item v-if="form.type !== 1" label="权限标识">
               <span slot="label">


### PR DESCRIPTION
这里给出vue2版本实现，完全依照ruoyi代码实现。
具体效果如图：
![image](https://github.com/yudaocode/yudao-ui-admin-vue2/assets/93857716/a8a3257a-dcbc-4e41-9288-c5d75301f495)

![image](https://github.com/yudaocode/yudao-ui-admin-vue2/assets/93857716/10030bcb-5344-4a12-9b41-645508ec12cd)

![image](https://github.com/yudaocode/yudao-ui-admin-vue2/assets/93857716/4e715216-44e3-4f45-9bb0-5dcc885c7290)

成功效果：
![image](https://github.com/yudaocode/yudao-ui-admin-vue2/assets/93857716/a36fcf27-5cb1-4c76-af05-ee3a84d38e46)

数据库：
![image](https://github.com/yudaocode/yudao-ui-admin-vue2/assets/93857716/d47e3e86-327b-40fd-93cf-58e73c969450)
